### PR TITLE
Implemented titleimage Layout

### DIFF
--- a/Backend Api/Repo Model/ModuleTitleImageContent.cs
+++ b/Backend Api/Repo Model/ModuleTitleImageContent.cs
@@ -1,0 +1,23 @@
+﻿using Backend_Api.Repo_Model;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BackendApi.Repo_Model
+{
+    public class ModuleTitleImageContent : ModuleBaseContent 
+    {
+        /**
+         * Constructs a new ModuleTitleImageContent.
+         **/
+        public ModuleTitleImageContent()
+        {
+            Type = "titleimage";
+        }
+
+        [JsonProperty(PropertyName = "Link")]
+        public string Link { get; set; }
+    }
+}

--- a/Backend Api/Repository/ModuleBaseTypeConverter.cs
+++ b/Backend Api/Repository/ModuleBaseTypeConverter.cs
@@ -1,4 +1,5 @@
 ﻿using Backend_Api.Repo_Model;
+using BackendApi.Repo_Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -39,6 +40,10 @@ namespace Backend_Api.Repository
                     else if (token["Type"].ToString().Equals("image"))
                     {
                         layoutList.Add(token.ToObject<ModuleImageContent>());
+                    }
+                    else if (token["Type"].ToString().Equals("titleimage"))
+                    {
+                        layoutList.Add(token.ToObject<ModuleTitleImageContent>());
                     }
                     else if (token["Type"].ToString().Equals("quiz"))
                     {


### PR DESCRIPTION
The Layout field now accepts a titleimage object, example:
{"Link":"myimage.jpg","Heading":"Holocracy Book","Type":"titleimage"}