### PR TITLE
Fixed erroneous 404 when no modules exist

### DIFF
--- a/Backend Api/Controllers/ModuleController.cs
+++ b/Backend Api/Controllers/ModuleController.cs
@@ -36,7 +36,7 @@ namespace Backend_Api.Controllers
         {
             var result = repository.GetAllModules();
 
-            if (result == null || !result.Any())
+            if (result == null)
             {
                 return NotFound();
             }


### PR DESCRIPTION
- Fixes 404 error when modules are present in the DB (doing GET with no ID)