### PR TITLE
Renamed UI website to enable Azure deployment

### DIFF
--- a/CSS566 Project.sln
+++ b/CSS566 Project.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Software Management Course Website", "Software Management Course Website\Software Management Course Website.csproj", "{D2FE0DB9-5FD8-4E6C-B052-F1E6D543DA00}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoftwareManagementCourseWebsite", "Software Management Course Website\SoftwareManagementCourseWebsite.csproj", "{D2FE0DB9-5FD8-4E6C-B052-F1E6D543DA00}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Module API", "Module API\Module API.csproj", "{5B046B8A-37F4-4297-BECB-FF6F83EDE35E}"
 EndProject
@@ -68,10 +68,6 @@ Global
 		{DBF9ACAA-FEC8-4913-8F05-D3B030C80878}.Debug|x86.Build.0 = Debug|Any CPU
 		{DBF9ACAA-FEC8-4913-8F05-D3B030C80878}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DBF9ACAA-FEC8-4913-8F05-D3B030C80878}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D2A5F054-07AA-43CB-8A57-A824E4AB3025}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D2A5F054-07AA-43CB-8A57-A824E4AB3025}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D2A5F054-07AA-43CB-8A57-A824E4AB3025}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D2A5F054-07AA-43CB-8A57-A824E4AB3025}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DBF9ACAA-FEC8-4913-8F05-D3B030C80878}.Release|x64.ActiveCfg = Release|Any CPU
 		{DBF9ACAA-FEC8-4913-8F05-D3B030C80878}.Release|x64.Build.0 = Release|Any CPU
 		{DBF9ACAA-FEC8-4913-8F05-D3B030C80878}.Release|x86.ActiveCfg = Release|Any CPU

--- a/Software Management Course Website/Properties/PublishProfiles/SoftwareManagementCourseWebsite20180528054255 - Web Deploy.pubxml
+++ b/Software Management Course Website/Properties/PublishProfiles/SoftwareManagementCourseWebsite20180528054255 - Web Deploy.pubxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>MSDeploy</WebPublishMethod>
+    <ResourceId>/subscriptions/b2dc14df-5726-47cc-9696-53abc222c7f0/resourcegroups/fuzzywombats/providers/Microsoft.Web/sites/SoftwareManagementCourseWebsite20180528054255</ResourceId>
+    <ResourceGroup>fuzzywombats</ResourceGroup>
+    <PublishProvider>AzureWebSite</PublishProvider>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish>http://softwaremanagementcoursewebsite20180528054255.azurewebsites.net</SiteUrlToLaunchAfterPublish>
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <ProjectGuid>d2fe0db9-5fd8-4e6c-b052-f1e6d543da00</ProjectGuid>
+    <MSDeployServiceURL>softwaremanagementcoursewebsite20180528054255.scm.azurewebsites.net:443</MSDeployServiceURL>
+    <DeployIisAppPath>SoftwareManagementCourseWebsite20180528054255</DeployIisAppPath>
+    <RemoteSitePhysicalPath />
+    <SkipExtraFilesOnServer>True</SkipExtraFilesOnServer>
+    <MSDeployPublishMethod>WMSVC</MSDeployPublishMethod>
+    <EnableMSDeployBackup>True</EnableMSDeployBackup>
+    <UserName>$SoftwareManagementCourseWebsite20180528054255</UserName>
+    <_SavePWD>True</_SavePWD>
+    <_DestinationType>AzureWebSite</_DestinationType>
+  </PropertyGroup>
+</Project>

--- a/Software Management Course Website/SoftwareManagementCourseWebsite.csproj
+++ b/Software Management Course Website/SoftwareManagementCourseWebsite.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <UserSecretsId>aspnet-Software_Management_Course_Website-BAA5353A-6C4C-4B09-8D36-576015AF60EA</UserSecretsId>
+    <AssemblyName>SoftwareManagementCourseWebsite</AssemblyName>
+    <RootNamespace>SoftwareManagementCourseWebsite</RootNamespace>
   </PropertyGroup>
 
 


### PR DESCRIPTION
- Renamed the UI web project (removed spaces from it) to allow for Azure deployment

Azure URL: http://softwaremanagementcoursewebsite20180528054255.azurewebsites.net

When you open Visual Studio, you can now right-click the "SoftwareManagementCourseWebsite" project and then select Publish. From there you should see the window below, click on "Publish" to deploy your local copy of the project to the web. In case you're prompted for a password, it's: QmxYEtkhLSzk1xC7vs2D98McDnNxyRZd9PsmxB11EKTRRNhlcM3MxWDR69oE
![image](https://user-images.githubusercontent.com/3317165/40632925-baae548c-62a0-11e8-9283-2410040c4811.png)

I used this tutorial to get Azure deployment working. It's pretty straight forward in case anyone wants to deploy elsewhere: https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-to-azure

